### PR TITLE
webview.setWebContentsDebuggingEnabled をセット

### DIFF
--- a/app/src/main/java/com/notainc/helpfeel_skeleton/HelpfeelActivity.kt
+++ b/app/src/main/java/com/notainc/helpfeel_skeleton/HelpfeelActivity.kt
@@ -93,6 +93,7 @@ class HelpfeelActivity : AppCompatActivity() {
 
         webview.settings.javaScriptEnabled = true
         webview.settings.javaScriptCanOpenWindowsAutomatically = true
+        WebView.setWebContentsDebuggingEnabled(true)
         webview.loadUrl(this.helpfeelUrl)
     }
 


### PR DESCRIPTION
ref. https://developers.google.com/web/tools/chrome-devtools/remote-debugging/webviews?hl=ja

- アプリをインストールしたスマホをUSBでPCと接続
- アプリを起動して記事ページを開く (WebView画面を開く)
- PC Chromeで chrome://inspect を開く
  - DevicesセクションにWebViewが表示される
  - [![Screenshot from Gyazo](https://gyazo.com/b179e98a0d810ac0ac568a5034f8772f/raw)](https://gyazo.com/b179e98a0d810ac0ac568a5034f8772f)
  - inspectをクリック